### PR TITLE
chore: add maintenance section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ Ready-to-use images for NodeJS.
 | NodeJS 8        | Alpine v3.7  | v8            |
 | NodeJS 7        | Alpine v3.6  | v7            |
 | NodeJS 6        | Alpine v3.6  | v6            |
+
+## Maintenance
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.


### PR DESCRIPTION
## What changed
- Added a `## Maintenance` section to README.
- Added the contribution reference line: `See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.`

## Why
- Makes maintenance expectations explicit and consistent across Dockette repositories.