### PR TITLE
chore: modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -30,22 +33,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image }}
           push: false
@@ -53,7 +56,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Load docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image }}
           load: true
@@ -70,7 +73,7 @@ jobs:
           fi
 
       - name: Push docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image }}
           push: true


### PR DESCRIPTION
## Summary
- update deprecated GitHub Action majors in workflow definitions (including actions/cache to v4)
- modernize Docker action majors to supported versions
- add explicit least-privilege workflow permissions (contents: read)

## Why
- prevent failures from deprecated action versions and keep CI workflows supportable
- make workflow token permissions explicit and minimal while preserving behavior