### PR TITLE
Add CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,8 @@ permissions:
   contents: read
 
 jobs:
-  docker:
+  test:
+    name: Test (dockette/nodejs:${{ matrix.image }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,7 +30,55 @@ jobs:
 
       fail-fast: false
 
-    name: Docker (dockette/nodejs:${{ matrix.image }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build docker image for testing
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image }}
+          load: true
+          tags: dockette/nodejs:${{ matrix.image }}
+
+      - name: Test node version
+        run: |
+          var="$(docker run --rm dockette/nodejs:${{ matrix.image }} node -v)"
+          if [[ $var =~ "${{ matrix.image }}" ]]; then
+              echo "Node version matched ${var} =~ ${{ matrix.image }}"
+          else
+              echo "Invalid node version ${var} != ${{ matrix.image }}"
+              exit 255
+          fi
+
+      - name: Test npm version
+        run: docker run --rm dockette/nodejs:${{ matrix.image }} npm -v
+
+  build:
+    name: Build (dockette/nodejs:${{ matrix.image }})
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: v6
+          - image: v7
+          - image: v8
+          - image: v9
+          - image: v10
+          - image: v11
+          - image: v12
+          - image: v13
+          - image: v14
+          - image: v15
+          - image: v16
+          - image: v17
+          - image: v18
+
+      fail-fast: false
 
     steps:
       - name: Checkout
@@ -47,31 +96,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.image }}
-          push: false
-          tags: dockette/nodejs:${{ matrix.image }}
-          platforms: linux/amd64,linux/arm64
-
-      - name: Load docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.image }}
-          load: true
-          tags: dockette/nodejs:${{ matrix.image }}
-
-      - name: Test node version
-        run: |
-          var="$(docker run --rm dockette/nodejs:${{ matrix.image }} node -v)"
-          if [[ $var =~ "${{ matrix.image }}" ]]; then
-              echo "Node version matched ${var} =~ ${{ matrix.image }}"
-          else
-              echo "Invalid node version ${var} != ${{ matrix.image }}"
-              exit 255
-          fi
-
       - name: Push docker image
         uses: docker/build-push-action@v6
         with:
@@ -79,3 +103,18 @@ jobs:
           push: true
           tags: dockette/nodejs:${{ matrix.image }}
           platforms: linux/amd64,linux/arm64
+
+  docs:
+    name: Docs
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: dockette/nodejs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Project
+
+Docker image repository in the Dockette organization.
+
+## Commands
+
+- `make build` builds the default Docker image.
+- `make test` runs the repository smoke tests.
+- `make run` starts the image for local use.
+
+## Guidelines
+
+- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Prefer `DOCKER_*` names for Docker-related Makefile variables.
+- Place `.PHONY: <target>` directly above each Makefile target.
+- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Do not introduce unrelated formatting or structural changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,35 @@
 
 ## Project
 
-Docker image repository in the Dockette organization.
+Dockette NodeJS publishes ready-to-use Docker images for legacy Node.js versions. All tags in this repository are EOL upstream and are kept for existing projects.
+
+## Images
+
+- Docker image: `dockette/nodejs`.
+- Default Makefile tag: `v18`.
+- Published tags and build contexts: `v6` through `v18`, each built from `./<tag>`.
+- Base images are `dockette/alpine:<version>` and vary by Node.js release.
+- GitHub Actions builds every tag from its matching context and publishes multi-arch images for `linux/amd64,linux/arm64`.
 
 ## Commands
 
-- `make build` builds the default Docker image.
-- `make test` runs the repository smoke tests.
-- `make run` starts the image for local use.
+- `make build` builds `dockette/nodejs:${DOCKER_VERSION}` with Docker Buildx.
+- `make build-all` builds all versioned tags.
+- `make test` checks `node -v` starts with the selected tag and verifies `npm -v` returns a value.
+- `make test-all` runs the smoke tests for every tag.
+- `make run` starts the selected image interactively.
+- Override `DOCKER_VERSION`, `DOCKER_IMAGE`, or `DOCKER_PLATFORMS` when testing a specific tag or platform.
+
+## Runtime Notes
+
+- There are no compose files in this repository.
+- The default container command is `nodejs` on newer images and `node` on older images; tests call `node -v`, so keep the executable available.
+- The images install Node.js and npm from Alpine packages, not from NodeSource or upstream tarballs.
 
 ## Guidelines
 
-- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Keep README tag tables, `DOCKER_VERSIONS`, version directories, and workflow matrices aligned when adding or removing a tag.
 - Prefer `DOCKER_*` names for Docker-related Makefile variables.
 - Place `.PHONY: <target>` directly above each Makefile target.
-- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Preserve the existing lightweight Dockerfile style and cleanup of package caches.
 - Do not introduce unrelated formatting or structural changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -3,20 +3,25 @@ DOCKER_VERSION?=v18
 DOCKER_PLATFORMS?=linux/amd64,linux/arm64
 DOCKER_VERSIONS=v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16 v17 v18
 
-.PHONY: build build-all test test-all run $(addprefix build-,$(DOCKER_VERSIONS)) $(addprefix test-,$(DOCKER_VERSIONS))
 
+.PHONY: build
 build: build-${DOCKER_VERSION}
 
+.PHONY: build-all
 build-all: $(addprefix build-,$(DOCKER_VERSIONS))
 
+.PHONY: test
 test: test-${DOCKER_VERSION}
 
+.PHONY: test-all
 test-all: $(addprefix test-,$(DOCKER_VERSIONS))
 
+.PHONY: run
 run:
 	docker run --rm -it ${DOCKER_IMAGE}:${DOCKER_VERSION}
 
 _docker-build-%: VERSION=$*
+.PHONY: _docker-build-%
 _docker-build-%:
 	docker buildx \
 		build \
@@ -26,6 +31,7 @@ _docker-build-%:
 		./${VERSION}
 
 _docker-test-%: VERSION=$*
+.PHONY: _docker-test-%
 _docker-test-%:
 	set -eu; \
 		node_version="$$(docker run --rm ${DOCKER_IMAGE}:${VERSION} node -v)"; \
@@ -37,30 +43,56 @@ _docker-test-%:
 		test -n "$$npm_version"; \
 		printf 'npm version %s\n' "$$npm_version"
 
+.PHONY: build-v6
 build-v6: _docker-build-v6
+.PHONY: build-v7
 build-v7: _docker-build-v7
+.PHONY: build-v8
 build-v8: _docker-build-v8
+.PHONY: build-v9
 build-v9: _docker-build-v9
+.PHONY: build-v10
 build-v10: _docker-build-v10
+.PHONY: build-v11
 build-v11: _docker-build-v11
+.PHONY: build-v12
 build-v12: _docker-build-v12
+.PHONY: build-v13
 build-v13: _docker-build-v13
+.PHONY: build-v14
 build-v14: _docker-build-v14
+.PHONY: build-v15
 build-v15: _docker-build-v15
+.PHONY: build-v16
 build-v16: _docker-build-v16
+.PHONY: build-v17
 build-v17: _docker-build-v17
+.PHONY: build-v18
 build-v18: _docker-build-v18
 
+.PHONY: test-v6
 test-v6: _docker-test-v6
+.PHONY: test-v7
 test-v7: _docker-test-v7
+.PHONY: test-v8
 test-v8: _docker-test-v8
+.PHONY: test-v9
 test-v9: _docker-test-v9
+.PHONY: test-v10
 test-v10: _docker-test-v10
+.PHONY: test-v11
 test-v11: _docker-test-v11
+.PHONY: test-v12
 test-v12: _docker-test-v12
+.PHONY: test-v13
 test-v13: _docker-test-v13
+.PHONY: test-v14
 test-v14: _docker-test-v14
+.PHONY: test-v15
 test-v15: _docker-test-v15
+.PHONY: test-v16
 test-v16: _docker-test-v16
+.PHONY: test-v17
 test-v17: _docker-test-v17
+.PHONY: test-v18
 test-v18: _docker-test-v18

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,26 @@
 DOCKER_IMAGE=dockette/nodejs
-DEFAULT_VERSION=v18
-VERSIONS=v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16 v17 v18
+DOCKER_VERSION?=v18
+DOCKER_PLATFORMS?=linux/amd64,linux/arm64
+DOCKER_VERSIONS=v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16 v17 v18
 
-.PHONY: build build-all test test-all run $(addprefix build-,$(VERSIONS)) $(addprefix test-,$(VERSIONS))
+.PHONY: build build-all test test-all run $(addprefix build-,$(DOCKER_VERSIONS)) $(addprefix test-,$(DOCKER_VERSIONS))
 
-build: build-$(DEFAULT_VERSION)
+build: build-${DOCKER_VERSION}
 
-build-all: $(addprefix build-,$(VERSIONS))
+build-all: $(addprefix build-,$(DOCKER_VERSIONS))
 
-test: test-$(DEFAULT_VERSION)
+test: test-${DOCKER_VERSION}
 
-test-all: $(addprefix test-,$(VERSIONS))
+test-all: $(addprefix test-,$(DOCKER_VERSIONS))
 
 run:
-	docker run --rm -it ${DOCKER_IMAGE}:${DEFAULT_VERSION}
+	docker run --rm -it ${DOCKER_IMAGE}:${DOCKER_VERSION}
 
 _docker-build-%: VERSION=$*
 _docker-build-%:
 	docker buildx \
 		build \
-		--platform linux/amd64,linux/arm64 \
+		--platform ${DOCKER_PLATFORMS} \
 		--pull \
 		-t ${DOCKER_IMAGE}:${VERSION} \
 		./${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,19 @@
 DOCKER_IMAGE=dockette/nodejs
+DEFAULT_VERSION=v18
+VERSIONS=v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16 v17 v18
+
+.PHONY: build build-all test test-all run $(addprefix build-,$(VERSIONS)) $(addprefix test-,$(VERSIONS))
+
+build: build-$(DEFAULT_VERSION)
+
+build-all: $(addprefix build-,$(VERSIONS))
+
+test: test-$(DEFAULT_VERSION)
+
+test-all: $(addprefix test-,$(VERSIONS))
+
+run:
+	docker run --rm -it ${DOCKER_IMAGE}:${DEFAULT_VERSION}
 
 _docker-build-%: VERSION=$*
 _docker-build-%:
@@ -8,6 +23,18 @@ _docker-build-%:
 		--pull \
 		-t ${DOCKER_IMAGE}:${VERSION} \
 		./${VERSION}
+
+_docker-test-%: VERSION=$*
+_docker-test-%:
+	set -eu; \
+		node_version="$$(docker run --rm ${DOCKER_IMAGE}:${VERSION} node -v)"; \
+		case "$$node_version" in \
+			${VERSION}*) printf 'Node version matched %s\n' "$$node_version" ;; \
+			*) printf 'Invalid node version %s != ${VERSION}\n' "$$node_version"; exit 255 ;; \
+		esac; \
+		npm_version="$$(docker run --rm ${DOCKER_IMAGE}:${VERSION} npm -v)"; \
+		test -n "$$npm_version"; \
+		printf 'npm version %s\n' "$$npm_version"
 
 build-v6: _docker-build-v6
 build-v7: _docker-build-v7
@@ -22,3 +49,17 @@ build-v15: _docker-build-v15
 build-v16: _docker-build-v16
 build-v17: _docker-build-v17
 build-v18: _docker-build-v18
+
+test-v6: _docker-test-v6
+test-v7: _docker-test-v7
+test-v8: _docker-test-v8
+test-v9: _docker-test-v9
+test-v10: _docker-test-v10
+test-v11: _docker-test-v11
+test-v12: _docker-test-v12
+test-v13: _docker-test-v13
+test-v14: _docker-test-v14
+test-v15: _docker-test-v15
+test-v16: _docker-test-v16
+test-v17: _docker-test-v17
+test-v18: _docker-test-v18

--- a/README.md
+++ b/README.md
@@ -15,23 +15,34 @@
 
 ## Usage
 
-| NodeJS          | OS           | Tag           |
-|-----------------|--------------|---------------|
-| NodeJS 18       | Alpine v3.17 | v18           |
-| NodeJS 17       | Alpine v3.16 | v17           |
-| NodeJS 16       | Alpine v3.15 | v16           |
-| NodeJS 15       | Alpine v3.14 | v15           |
-| NodeJS 14       | Alpine v3.14 | v14           |
-| NodeJS 13       | Alpine v3.11 | v13           |
-| NodeJS 12       | Alpine v3.12 | v12           |
-| NodeJS 11       | Alpine v3.9  | v11           |
-| NodeJS 10       | Alpine v3.8  | v10           |
-| NodeJS 9        | Alpine v3.7  | v9            |
-| NodeJS 8        | Alpine v3.7  | v8            |
-| NodeJS 7        | Alpine v3.6  | v7            |
-| NodeJS 6        | Alpine v3.6  | v6            |
+| NodeJS          | Base image              | Tag           |
+|-----------------|-------------------------|---------------|
+| NodeJS 18       | Alpine v3.17            | v18           |
+| NodeJS 17       | Alpine v3.15            | v17           |
+| NodeJS 16       | Alpine v3.16            | v16           |
+| NodeJS 15       | Alpine v3.13            | v15           |
+| NodeJS 14       | Alpine v3.14            | v14           |
+| NodeJS 13       | Alpine v3.11            | v13           |
+| NodeJS 12       | Alpine v3.12            | v12           |
+| NodeJS 11       | Alpine v3.9             | v11           |
+| NodeJS 10       | `node:10-alpine`        | v10           |
+| NodeJS 9        | `node:9-alpine`         | v9            |
+| NodeJS 8        | `node:8-alpine`         | v8            |
+| NodeJS 7        | Alpine v3.6             | v7            |
+| NodeJS 6        | Alpine v3.6             | v6            |
 
 These tags are kept for legacy projects. All published NodeJS versions in this repository are EOL upstream.
+
+Tags `v8`, `v9`, and `v10` use the floating official Node Alpine images above, so the exact Alpine minor version is determined by Docker Hub when those images are resolved.
+
+## Makefile
+
+- `make build` builds `dockette/nodejs:${DOCKER_VERSION}` with Docker Buildx.
+- `make build-all` builds all versioned tags from `v6` through `v18`.
+- `make test` runs smoke tests for `dockette/nodejs:${DOCKER_VERSION}`.
+- `make test-all` runs smoke tests for all versioned tags.
+- `make run` starts `dockette/nodejs:${DOCKER_VERSION}` interactively.
+- `DOCKER_VERSION` selects the tag for `build`, `test`, and `run`; it defaults to `v18`.
 
 ## Maintenance
 See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# NodeJS
+<h1 align=center>Dockette / NodeJS</h1>
 
-Ready-to-use images for NodeJS.
+<p align=center>
+   <a href="https://github.com/dockette/nodejs/actions"><img src="https://github.com/dockette/nodejs/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/nodejs"><img src="https://img.shields.io/docker/pulls/dockette/nodejs.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
+
+<p align=center>
+   Ready-to-use images for NodeJS.
+</p>
 
 -----
-
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/nodejs.svg?style=flat)](https://hub.docker.com/r/dockette/nodejs/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/nodejs.svg?style=flat)](https://hub.docker.com/r/dockette/nodejs/)
-
-## Discussion / Help
-
-[![Join the chat](https://img.shields.io/gitter/room/dockette/dockette.svg?style=flat-square)](https://gitter.im/dockette/dockette?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Usage
 
@@ -28,6 +30,8 @@ Ready-to-use images for NodeJS.
 | NodeJS 8        | Alpine v3.7  | v8            |
 | NodeJS 7        | Alpine v3.6  | v7            |
 | NodeJS 6        | Alpine v3.6  | v6            |
+
+These tags are kept for legacy projects. All published NodeJS versions in this repository are EOL upstream.
 
 ## Maintenance
 See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.


### PR DESCRIPTION
What changed
- Split the Docker workflow into Test, Build, and Docs jobs while preserving the master-branch image publish path.
- Added Docker Hub README description publishing for dockette/nodejs.
- Added Makefile build/build-all/test/test-all/run aliases with node/npm smoke tests.
- Normalized README badges to the Dockette copybara style and documented legacy/EOL Node tags.

Why
- Align dockette/nodejs with the Dockette CI rollout baseline and current README badge/maintenance conventions.